### PR TITLE
fix calc cluster size

### DIFF
--- a/UnitTest/iterator_test.cpp
+++ b/UnitTest/iterator_test.cpp
@@ -49,6 +49,15 @@ namespace UnitTest
 			Assert::IsTrue((*it) == u'a');
 		}
 
+		TEST_METHOD(TestCompareSurrogate)
+		{
+			basic_grapheme_cluster_string text(u"a𡸴𣷹𣏓");
+
+			auto it = text.begin();
+			std::advance(it, 1);
+			Assert::IsTrue((*it) == u"𡸴");
+		}
+
 		TEST_METHOD(TestInsert)
 		{
 			basic_grapheme_cluster_string text(u"abcd");

--- a/grapheme_cluster_iterator/include/detail/grapheme_cluster_type.h
+++ b/grapheme_cluster_iterator/include/detail/grapheme_cluster_type.h
@@ -19,9 +19,7 @@ namespace yol::detail {
 		std::basic_string_view<char_type> operator=(std::basic_string_view<char_type> c)
 		{
 			auto& buffer = m_owner->get_buffer();
-			auto view = m_owner->get_view().substr(m_index);
-			auto size = cluster_traits::calc_cluster_size(view);
-
+			auto size = view().length();
 			buffer.erase(m_index, size);
 			buffer.insert(m_index, c);
 
@@ -30,9 +28,9 @@ namespace yol::detail {
 
 		std::basic_string_view<char_type> view() const
 		{
-			auto view = m_owner->get_view();
+			auto view = m_owner->get_view().substr(m_index);
 			auto size = cluster_traits::calc_cluster_size(view);
-			return view.substr(m_index, size);
+			return view.substr(0, size);
 		}
 
 		bool operator==(char_type c) const


### PR DESCRIPTION
文字を取得する際、クラスタサイズの計算が先頭の文字で固定されていたのを修正